### PR TITLE
clientX and clientY to pageX and pageY

### DIFF
--- a/tooltip.js
+++ b/tooltip.js
@@ -26,8 +26,8 @@ function initTooltip() {
 
 	const handleMouseMove = {
 		handleEvent(e) {
-			this.tooltipbox.style.top = e.clientY + 25 + 'px';
-			this.tooltipbox.style.left = e.clientX + 13 +'px';
+			this.tooltipbox.style.top = e.pageY + 25 + 'px';
+			this.tooltipbox.style.left = e.pageX + 13 + 'px';
 		}
 	}
 
@@ -37,7 +37,7 @@ function initTooltip() {
 		tooltip.classList.add('tooltip');
 
 		document.body.appendChild(tooltip);
-		
+
 		return tooltip;
 	}
 }


### PR DESCRIPTION
Enable support for websites that scroll. clientX and clientY are relative to the screen's width and height. pageX and pageY are fixed values based on the entire document's width and height.